### PR TITLE
Fix missing language attribute handling

### DIFF
--- a/Sources/ReadabilityCore/ReadabilityResult.swift
+++ b/Sources/ReadabilityCore/ReadabilityResult.swift
@@ -18,7 +18,7 @@ public struct ReadabilityResult: Decodable, Sendable {
     /// The name of the site where the article originated.
     public let siteName: String?
     /// The language of the article.
-    public let language: String
+    public let language: String?
     /// The text direction (e.g., "ltr", "rtl") of the article, if available.
     public let direction: String?
     /// The published time of the article, if available.

--- a/Sources/ReadabilityUI/Internal/ReaderContentGenerator.swift
+++ b/Sources/ReadabilityUI/Internal/ReaderContentGenerator.swift
@@ -36,7 +36,7 @@ struct ReaderContentGenerator: ReaderContentGeneratable {
             .replacingOccurrences(of: "%READER-TITLE%", with: readabilityResult.title)
             .replacingOccurrences(of: "%READER-BYLINE%", with: readabilityResult.byline ?? "")
             .replacingOccurrences(of: "%READER-CONTENT%", with: readabilityResult.content)
-            .replacingOccurrences(of: "%READER-LANGUAGE%", with: readabilityResult.language)
+            .replacingOccurrences(of: "%READER-LANGUAGE%", with: readabilityResult.language ?? "en")
             .replacingOccurrences(of: "%READER-DIRECTION%", with: readabilityResult.direction ?? "auto")
     }
 }


### PR DESCRIPTION
## Summary
Fixed a JSON decoding failure in `ReadabilityMessageHandler` when HTML documents lack a `lang` attribute.

## Root Cause
`ReadabilityMessageHandler.swift:55` fails to decode `ReadabilityResult` from JSON when the `language` field is null, because it was defined as non-optional `String` which violates `Codable` requirements.

## Changes
- Made `ReadabilityResult.language` optional to allow null values during decoding
- Added fallback to "en" in `ReaderContentGenerator` when language is nil

Fixes #5